### PR TITLE
Accept extended year

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ module.exports = isDate;
  * Matching format per: http://www.w3.org/TR/NOTE-datetime
  */
 
-var isoformat = '^\\d{4}-\\d{2}-\\d{2}' +        // Match YYYY-MM-DD
+var isoformat = '^([\+-]\\d{2})?' +              // Match ±YY
+                '\\d{4}-\\d{2}-\\d{2}' +         // Match YYYY-MM-DD
                 '((T\\d{2}:\\d{2}(:\\d{2})?)' +  // Match THH:mm:ss
                 '(\\.\\d{1,6})?' +               // Match .sssss
                 '(Z|(\\+|-)\\d{2}:\\d{2})?)?$';  // Time zone (Z or +hh:mm)


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString, `Date.toISOString()` accept two formats of 24 and 27 characters long. This adds support for the second one, that's with 6 digits years when they are prefixed with a plus or minus character.